### PR TITLE
[TASK] 게이트웨이 인증 필터 관련 통합테스트 코드 작성

### DIFF
--- a/docs/gateway-server-integration-test-report.md
+++ b/docs/gateway-server-integration-test-report.md
@@ -1,0 +1,50 @@
+# 게이트웨이 서버 통합 테스트 구현 보고서
+
+이 문서는 게이트웨이 서버(`gateway-server`)의 핵심 로직인 인증 필터(`JwtGatewayFilter`) 및 보안 정책에 대한 통합 테스트 구현 내역을 정리합니다.
+
+## 1. 개요
+조만간 예정된 **WebFlux 기반 게이트웨이로의 리팩토링**을 대비하여, 현재 서블릿 기반 환경에서의 비즈니스 정합성(인증, 헤더 주입, 보안 등)을 보장하기 위한 통합 테스트를 작성했습니다.
+
+## 2. 테스트 환경 및 전략
+- **도구**: `JUnit 5`, `MockMvc`, `Mockito`
+- **전략**: 
+  - 외부 서비스(`user-service`) 호출은 `FeignClient`를 `@MockBean`으로 처리하여 격리된 테스트 수행.
+  - 게이트웨이가 하위 서비스로 전달하는 헤더를 검증하기 위해 테스트 내부 전용 `TestDownstreamController`를 정의.
+  - 나중에 WebFlux로 전환 시 테스트 코드 수정을 최소화할 수 있도록 비즈니스 로직(결과 헤더 검증) 위주로 구성.
+
+## 3. 테스트 시나리오
+작성된 `JwtGatewayIntegrationTest`는 다음 4가지 핵심 시나리오를 검증합니다.
+
+| 시나리오 | 검증 내용 | 결과 |
+| :--- | :--- | :---: |
+| **인증 성공 및 헤더 주입** | 유효한 토큰 요청 시 `x-user-id`, `x-user-roles` 헤더가 정상 주입되는지 확인 | **PASS** |
+| **블랙리스트 차단** | 로그아웃된 토큰 요청 시 인증 서비스(`user-service`) 연동을 통해 401 응답 확인 | **PASS** |
+| **화이트리스트 통과** | 로그인, 회원가입 등 인증 제외 경로가 토큰 없이 정상 동작하는지 확인 | **PASS** |
+| **헤더 스푸핑 방지** | 클라이언트가 보낸 임의의 `x-user-` 헤더가 무시되고 인증 정보로 덮어써지는지 확인 | **PASS** |
+
+## 4. 기술적 이슈 및 해결 내역
+
+### 4.1 TokenType 매칭 오류 (401 Unauthorized)
+- **문제**: 테스트 코드에서 `tokenType`을 `"ACCESS"`로 주입했으나 필터에서 검증 실패.
+- **원인**: 공통 모듈의 `TokenType` enum이 내부 필드 `value`를 기준으로 `"access"` (소문자)와 매칭하도록 구현되어 있었음.
+- **해결**: Claims 생성 시 `TokenType.ACCESS.getValue()` 값인 `"access"`를 사용하도록 수정.
+
+### 4.2 응답 구조 불일치 (PathNotFoundException)
+- **문제**: `$.userId` 경로로 JSON 결과를 찾지 못해 테스트 실패.
+- **원인**: 프로젝트의 `CommonResponseAdvice`가 적용되어 모든 응답이 `{"success":..., "data":{...}}` 구조로 감싸짐.
+- **해결**: JSON Path를 `$.data.userId`, `$.data.roles`로 수정하여 실제 데이터 영역을 검증하도록 변경.
+
+### 4.3 WebTestClient 의존성 이슈
+- **문제**: WebFlux 전환을 고려해 `WebTestClient`를 쓰려 했으나, MVC 환경에서 이를 사용하려면 `spring-webflux` 라이브러리가 테스트 클래스패스에 추가되어야 함.
+- **결정**: 현재 프로젝트의 순수성을 유지하기 위해 추가 의존성 없이 `MockMvc`를 사용하되, 테스트 로직을 단순화하여 나중에 교체가 쉽도록 구현함.
+
+## 5. 향후 WebFlux 리팩토링 시 가이드
+현재 작성된 테스트 코드는 비즈니스 로직 검증에 집중되어 있으므로, WebFlux 마이그레이션 시 다음 부분만 수정하면 됩니다.
+
+1. **테스트 클라이언트 변경**: `MockMvc` 대신 `WebTestClient` 사용 (이때 `spring-boot-starter-webflux` 의존성 필요).
+2. **바인딩 방식 수정**: `MockMvcWebTestClient` 대신 WebFlux용 `WebTestClient.bindToApplicationContext()` 사용.
+3. **결과 검증**: 현재 `andExpect(jsonPath(...))` 문법은 `WebTestClient`에서도 거의 동일하게 지원하므로 로직 재사용 가능.
+
+---
+**작성일**: 2026-05-08  
+**작성자**: Gemini CLI

--- a/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
+++ b/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
@@ -36,7 +36,11 @@ import java.util.UUID;
 public class JwtGatewayFilter extends OncePerRequestFilter {
 
     private static final String HEADER_TRACE_ID = "X-Trace-Id";
-    private static final List<String> WHITELIST = List.of("/api/v1/auth/login", "/api/v1/auth/signup", "/api/v1/auth/reissue");
+    private static final List<String> WHITELIST = List.of(
+            "/api/v1/auth/login",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/reissue"
+    );
 
     private final Tracer tracer;
     private final TokenProvider jwtTokenProvider;
@@ -66,13 +70,21 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
         String accessToken = JwtUtils.resolveToken(request.getHeader(HttpHeaders.AUTHORIZATION));
         String path = request.getRequestURI();
 
-        // 2. 토큰이 없거나, 화이트리스트 경로인 경우: 즉시 통과
-        if (WHITELIST.contains(path) || accessToken == null) {
+        // 2. 화이트리스트 경로인 경우: 즉시 통과
+        if (WHITELIST.contains(path)) {
             filterChain.doFilter(mutableRequest, response);
             return;
         }
 
-        // 3. 통합 인증 프로세스 수행 (로컬 검증 -> 원격 검증 -> 헤더 주입)
+        // 3. 토큰이 없는 경우: 즉시 차단 (화이트리스트 제외)
+        if (accessToken == null) {
+            log.warn("[JwtGatewayFilter] Access 토큰 누락 - 차단 (TraceID: {})", traceId);
+            customAuthenticationEntryPoint.commence(request, response,
+                    new InsufficientAuthenticationException("Access 토큰이 필요합니다."));
+            return;
+        }
+
+        // 4. 통합 인증 프로세스 수행 (로컬 검증 -> 원격 검증 -> 헤더 주입)
         if (!authenticate(mutableRequest, response, accessToken, traceId)) {
             return; // 검증 실패 시 응답 종료
         }

--- a/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
+++ b/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
@@ -158,6 +158,6 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
     private String encodeValue(String value) {
         return Optional.ofNullable(value)
                 .map(val -> URLEncoder.encode(val, StandardCharsets.UTF_8))
-                .orElse("");
+                .orElse(null);
     }
 }

--- a/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
+++ b/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
@@ -20,6 +20,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.UUID;
 public class JwtGatewayFilter extends OncePerRequestFilter {
 
     private static final String HEADER_TRACE_ID = "X-Trace-Id";
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
     private static final List<String> WHITELIST = List.of(
             "/api/v1/auth/login",
             "/api/v1/auth/signup",
@@ -70,8 +72,8 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
         String accessToken = JwtUtils.resolveToken(request.getHeader(HttpHeaders.AUTHORIZATION));
         String path = request.getRequestURI();
 
-        // 2. 화이트리스트 경로인 경우: 즉시 통과
-        if (WHITELIST.contains(path)) {
+        // 2. 화이트리스트 경로인 경우: 즉시 통과 (패턴 매칭 지원)
+        if (isWhitelisted(path)) {
             filterChain.doFilter(mutableRequest, response);
             return;
         }
@@ -90,6 +92,11 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(mutableRequest, response);
+    }
+
+    private boolean isWhitelisted(String path) {
+        return WHITELIST.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     /**

--- a/src/test/java/org/pgsg/gateway/JwtGatewayIntegrationTest.java
+++ b/src/test/java/org/pgsg/gateway/JwtGatewayIntegrationTest.java
@@ -71,7 +71,7 @@ class JwtGatewayIntegrationTest {
     void success_token_injection() throws Exception {
         // given
         String token = "valid-token";
-        String userId = "12345";
+        String userId = "00000000-0000-0000-0000-000000000001";
         String role = "ROLE_USER";
 
         Mockito.when(tokenProvider.validateToken(token)).thenReturn(true);
@@ -99,7 +99,7 @@ class JwtGatewayIntegrationTest {
     }
 
     @Test
-    @DisplayName("블랙리스트 토큰 요청 시 401 에러를 반환해야 한다")
+    @DisplayName("검증한 토큰이 블랙리스트에 포함되어 있다면 401 에러를 반환해야 한다")
     void fail_blacklisted_token() throws Exception {
         // given
         String token = "blacklisted-token";
@@ -116,10 +116,17 @@ class JwtGatewayIntegrationTest {
     }
 
     @Test
-    @DisplayName("화이트리스트 경로는 토큰 없이 통과되어야 한다")
+    @DisplayName("화이트리스트에 포함된 경로는 유효한 토큰 없이도 통과되어야 한다")
     void success_whitelist() throws Exception {
         mockMvc.perform(get("/api/v1/auth/login"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("화이트리스트에 포함되지 않은 경로는 유효한 토큰이 없으면 차단되어야 한다")
+    void fail_nonWhitelist_noToken() throws Exception {
+        mockMvc.perform(get("/test/headers")) // 비화이트리스트 경로
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -127,7 +134,7 @@ class JwtGatewayIntegrationTest {
     void success_spoofing_protection() throws Exception {
         // given
         String token = "valid-token";
-        String realUserId = "12345";
+        String realUserId = "00000000-0000-0000-0000-000000000001";
 
         Mockito.when(tokenProvider.validateToken(token)).thenReturn(true);
         Claims claims = Jwts.claims()

--- a/src/test/java/org/pgsg/gateway/JwtGatewayIntegrationTest.java
+++ b/src/test/java/org/pgsg/gateway/JwtGatewayIntegrationTest.java
@@ -1,0 +1,152 @@
+package org.pgsg.gateway;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pgsg.common.response.CommonResponse;
+import org.pgsg.config.security.token.TokenProvider;
+import org.pgsg.gateway.auth.AuthDto;
+import org.pgsg.gateway.feign.AuthClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.pgsg.config.security.jwt.JwtUtils;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class JwtGatewayIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthClient authClient;
+
+    /**
+     * 테스트용 컨트롤러: 게이트웨이 필터를 거쳐 주입된 헤더를 확인하는 용도
+     */
+    @TestConfiguration
+    @RestController
+    static class TestDownstreamController {
+        @GetMapping("/test/headers")
+        public Map<String, String> getHeaders(
+                @RequestHeader(value = "x-user-id", required = false) String userId,
+                @RequestHeader(value = "x-user-roles", required = false) String roles
+        ) {
+            return Map.of(
+                    "userId", userId != null ? userId : "null",
+                    "roles", roles != null ? roles : "null"
+            );
+        }
+
+        @GetMapping("/api/v1/auth/login")
+        public String whitelist() {
+            return "ok";
+        }
+    }
+
+    @Test
+    @DisplayName("유효한 토큰 요청 시 사용자 헤더가 정상 주입되어야 한다")
+    void success_token_injection() throws Exception {
+        // given
+        String token = "valid-token";
+        String userId = "12345";
+        String role = "ROLE_USER";
+
+        Mockito.when(tokenProvider.validateToken(token)).thenReturn(true);
+        
+        Claims claims = Jwts.claims()
+                .subject(userId)
+                .add(JwtUtils.CLAIM_USER_ROLE, role)
+                .add(JwtUtils.CLAIM_TOKEN_TYPE, "access") // TokenType.ACCESS.getValue() 값인 "access" 사용
+                .add(JwtUtils.CLAIM_USERNAME, "tester")
+                .add(JwtUtils.CLAIM_NAME, "TesterName")
+                .add(JwtUtils.CLAIM_NICKNAME, "TestNick")
+                .add(JwtUtils.CLAIM_ENABLED, true)
+                .build();
+        Mockito.when(tokenProvider.parseClaims(token)).thenReturn(claims);
+
+        Mockito.when(authClient.verifyToken(any()))
+                .thenReturn(new CommonResponse<>(true, "success", new AuthDto.TokenVerifyData(true), null));
+
+        // when & then
+        mockMvc.perform(get("/test/headers")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(userId))
+                .andExpect(jsonPath("$.data.roles").value(role));
+    }
+
+    @Test
+    @DisplayName("블랙리스트 토큰 요청 시 401 에러를 반환해야 한다")
+    void fail_blacklisted_token() throws Exception {
+        // given
+        String token = "blacklisted-token";
+        Mockito.when(tokenProvider.validateToken(token)).thenReturn(true);
+        
+        // 원격 검증에서 실패(블랙리스트) 반환
+        Mockito.when(authClient.verifyToken(any()))
+                .thenReturn(new CommonResponse<>(true, "fail", new AuthDto.TokenVerifyData(false), null));
+
+        // when & then
+        mockMvc.perform(get("/test/headers")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("화이트리스트 경로는 토큰 없이 통과되어야 한다")
+    void success_whitelist() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/login"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("외부에서 주입한 보안 헤더(x-user-)는 무시되어야 한다")
+    void success_spoofing_protection() throws Exception {
+        // given
+        String token = "valid-token";
+        String realUserId = "12345";
+
+        Mockito.when(tokenProvider.validateToken(token)).thenReturn(true);
+        Claims claims = Jwts.claims()
+                .subject(realUserId)
+                .add(JwtUtils.CLAIM_USER_ROLE, "ROLE_USER")
+                .add(JwtUtils.CLAIM_TOKEN_TYPE, "access") // "access" 사용
+                .add(JwtUtils.CLAIM_USERNAME, "tester")
+                .add(JwtUtils.CLAIM_NAME, "TesterName")
+                .add(JwtUtils.CLAIM_NICKNAME, "TestNick")
+                .add(JwtUtils.CLAIM_ENABLED, true)
+                .build();
+        Mockito.when(tokenProvider.parseClaims(token)).thenReturn(claims);
+        Mockito.when(authClient.verifyToken(any())).thenReturn(new CommonResponse<>(true, "success", new AuthDto.TokenVerifyData(true), null));
+
+        // when & then
+        mockMvc.perform(get("/test/headers")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .header("x-user-id", "99999")) // 스푸핑 시도
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(realUserId)); // 게이트웨이가 주입한 값이어야 함
+    }
+}


### PR DESCRIPTION
### 작업 배경
- 게이트웨이 관련 ci/cd 수행 시 활용할 검증용 테스트코드 추가

### 작업 내용
- JwtGatewayFilter의 핵심 로직 검증용 통합테스트 코드 추가

### 테스트 여부

- JwtGatewayFilter의 주요 로직에 관한 통합 테스트 코드 실행 및 통과 확인
- `gradle clean build` 명령어 실행 시 정상적으로 빌드됨을 확인

<details>

<summary>테스트 진행 결과</summary>

<img width="981" height="604" alt="image" src="https://github.com/user-attachments/assets/ecd81b3a-fe50-4416-a989-dc83e5b109e9" />

</details>

### 기타

- 게이트웨이 JwtGatewayFilter의 세부 로직을 수정하는 대신, user-service의 Jwt 인증 필터의 세부 로직을 게이트웨이에 맞춰 원상복구하는 방향으로 진행합니다.
- 서블릿 기반 게이트웨이를 WebFlux 기반으로 전환하는 작업은 1차 과부하테스트를 마친 뒤에 시작할 예정입니다.

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #6 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 요청 추적 ID를 초기화해 헤더/로그에 삽입하고 기존 사용자 헤더를 제거
  * 경로 패턴 기반 화이트리스트로 인증 우회 지원 및 원격 블랙리스트 검증 도입
  * JWT 검증 후 사용자 관련 헤더를 주입(클레임 값 URL 인코딩)

* **버그 수정**
  * 선택적 클레임 누락 처리 개선(값 없을 시 헤더 미설정)
  * 스푸핑된 x-user-* 헤더 무시 처리 보강

* **문서**
  * 게이트웨이 인증 필터 통합 테스트 보고서(한글) 추가

* **테스트**
  * 통합 테스트로 인증/블랙리스트/화이트리스트/헤더 주입 시나리오 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->