### PR TITLE
chore : github action 배포 워크플로우 세부 스크립트 수정

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,10 +109,10 @@ jobs:
       matrix:
         include:
           - vm: gateway-server-1
-            zone: asia-northeast3-b
+            zone: asia-northeast3-a
           # 나중에 3대로 늘릴 때 아래 주석 해제
           # - vm: gateway-server-2
-          #   zone: asia-northeast3-a
+          #   zone: asia-northeast3-b
           # - vm: gateway-server-3
           #   zone: asia-northeast3-c
     steps:
@@ -177,8 +177,8 @@ jobs:
               export IMAGE_TAG='$NEW_TAG'
               export AR_IMAGE_PATH='${{ env.AR_IMAGE_PATH }}'
 
-              sudo -E docker compose -f docker-compose.prod.yaml pull
-              sudo -E docker compose -f docker-compose.prod.yaml up -d
+              sudo env IMAGE_TAG="$NEW_TAG" AR_IMAGE_PATH="${{ env.AR_IMAGE_PATH }}" docker compose -f docker-compose.prod.yaml pull
+              sudo env IMAGE_TAG="$NEW_TAG" AR_IMAGE_PATH="${{ env.AR_IMAGE_PATH }}" docker compose -f docker-compose.prod.yaml up -d
 
               echo 'Checking actuator health (max $HEALTH_RETRIES x ${HEALTH_INTERVAL}s)...'
               HEALTHY=0
@@ -225,8 +225,8 @@ jobs:
                 export IMAGE_TAG='$ROLLBACK_TAG'
                 export AR_IMAGE_PATH='${{ env.AR_IMAGE_PATH }}'
 
-                sudo -E docker compose -f docker-compose.prod.yaml pull
-                sudo -E docker compose -f docker-compose.prod.yaml up -d
+                sudo env IMAGE_TAG="$ROLLBACK_TAG" AR_IMAGE_PATH="${{ env.AR_IMAGE_PATH }}" docker compose -f docker-compose.prod.yaml pull
+                sudo env IMAGE_TAG="$ROLLBACK_TAG" AR_IMAGE_PATH="${{ env.AR_IMAGE_PATH }}" docker compose -f docker-compose.prod.yaml up -d
 
                 for i in \$(seq 1 18); do
                   if curl -sf http://localhost:8090/actuator/health \
@@ -265,7 +265,9 @@ jobs:
 
   promote-stable:
     needs: [ build-and-push, deploy ]
-    if: github.ref == 'refs/heads/main'
+    if: |
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&
+      needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production

--- a/deploy/ar-image-retention-policy.json
+++ b/deploy/ar-image-retention-policy.json
@@ -4,7 +4,7 @@
     "action": {
       "type": "Keep"
     },
-    "condition": {
+    "mostRecentVersions": {
       "keepCount": 3
     }
   }

--- a/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
+++ b/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
@@ -42,7 +42,9 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
             "/api/v1/auth/login",
             "/api/v1/auth/signup",
             "/api/v1/auth/reissue",
-            "/actuator/**"
+            "/actuator/health",
+            "/actuator/health/**",
+            "/actuator/info"
     );
 
     private final Tracer tracer;

--- a/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
+++ b/src/main/java/org/pgsg/gateway/filter/JwtGatewayFilter.java
@@ -41,7 +41,8 @@ public class JwtGatewayFilter extends OncePerRequestFilter {
     private static final List<String> WHITELIST = List.of(
             "/api/v1/auth/login",
             "/api/v1/auth/signup",
-            "/api/v1/auth/reissue"
+            "/api/v1/auth/reissue",
+            "/actuator/**"
     );
 
     private final Tracer tracer;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,11 +13,5 @@ spring:
       discovery:
         service-id: config-server
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, refresh
-
 server:
   port: 8090


### PR DESCRIPTION
### 작업 배경
- 게이트웨이 서버에 관한 GCP 배포가 원활하게 진행되는지 확인

### 작업 내용

- gateway-server-1의 영역을 asia-northeast3-a로 수정
- main 또는 dev 브랜치에서 배포 성공 시 promote-remote job이 자동 실행되도록 실행 조건 수정

### 테스트 여부
- 배포 테스트는 현재 pr에서 수동으로 진행 -> 게이트웨이용 VM 1대 구동 시 정상 배포됨을 확인

### 기타
- 유레카 서버와는 아직 연동되지 않은 상태로 게이트웨이를 GCP VM에 배포하는 작업만 먼저 수행하여 나중에 별도의 연동 작업이 필요합니다.
- 게이트웨이 3대+nginx 연동은 별도로 작업 진행 예정  
  - 게이트웨이 서버 간 로드밸런싱을 수행하려면 클라이언트-서버 간 로드밸런싱을 수행하는 nginx 도입 필요

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- This closes #10 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 배포 워크플로우의 대상 가용영역 및 원격 배포 환경 변수 전달 방식 조정으로 배포 안정성 및 환경 전달 개선
  * 배포 후 “stable” 태그 승격 조건 확대로 승격 범위 확대
  * 이미지 보존 정책을 최근 이미지 3개 보관 방식으로 변경
  * 운영용 헬스·정보 엔드포인트에 대한 인증 우회 범위 확대 및 관리 노출 설정 정리

이 릴리스는 주로 운영·배포 관련 개선이며 최종 사용자 기능 변화는 없습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/gateway-server/pull/11)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->