### PR TITLE
[TASK] nginx 배포 워크플로우 테스트

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ HOSTNAME=localhost
 # 배포 환경에서도 공통 모듈을 적용하기 위해 Dockerfile에 추가해야 할 환경변수
 GPR_USER=GitHub_ID
 GPR_TOKEN=GitHub_Personal_Access_Token(PAT)
+
+EUREKA_SERVER_URL=http://localhost:8761/eureka/

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -60,7 +60,7 @@ jobs:
             --project="$GCP_PROJECT" \
             --tunnel-through-iap
 
-        # 기존 gateway.conf를 백업 후 제거 → 검증 → 복구 또는 교체
+        # 기존 conf 백업(있을 때만) → 임시 파일 검증 → 반영 → reload 실패 시 백업 복구 → 성공 시 백업 제거
       - name: Apply nginx.conf and reload
         run: |
           gcloud compute ssh $NGINX_VM \
@@ -69,19 +69,29 @@ jobs:
             --tunnel-through-iap \
             --command="
               set -e
-          
-              sudo mv /etc/nginx/conf.d/gateway.conf /etc/nginx/conf.d/gateway.conf.bak
+
+              if [ -f /etc/nginx/conf.d/gateway.conf ]; then
+                sudo cp /etc/nginx/conf.d/gateway.conf /etc/nginx/conf.d/gateway.conf.bak
+              fi
+
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.tmp.conf
               if ! sudo nginx -t; then
                 echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
                 sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
-                sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
                 exit 1
               fi
-              sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
-              sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
-              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
-              sudo nginx -s reload
+
+              sudo mv /etc/nginx/conf.d/gateway.conf.tmp.conf /etc/nginx/conf.d/gateway.conf
+
+              if ! sudo nginx -s reload; then
+                echo '❌ nginx reload failed — restoring backup'
+                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                sudo nginx -s reload
+                exit 1
+              fi
+
+              sudo rm -f /etc/nginx/conf.d/gateway.conf.bak
               echo '✅ Nginx reloaded successfully'
             "
 

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -69,7 +69,7 @@ jobs:
             --command="
               set -e
           
-              if ! sudo nginx -t -c /etc/nginx/nginx.conf -g "include /tmp/nginx.conf;"; then
+              if ! sudo nginx -t -c /etc/nginx/nginx.conf -g \"include /tmp/nginx.conf;\"; then
               echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
               exit 1
               fi

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -69,10 +69,13 @@ jobs:
             --command="
               set -e
           
-              if ! sudo nginx -t -c /etc/nginx/nginx.conf -g \"include /tmp/nginx.conf;\"; then
-              echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
-              exit 1
+              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.tmp.conf
+              if ! sudo nginx -t; then
+                echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
+                sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
+                exit 1
               fi
+              sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
               sudo nginx -s reload
               echo '✅ Nginx reloaded successfully'

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -69,14 +69,15 @@ jobs:
             --command="
               set -e
           
-              sudo nginx -t -c /tmp/nginx.conf
+              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.test
+              sudo nginx -t
               if [ \$? -ne 0 ]; then
                 echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
+                sudo rm /etc/nginx/conf.d/gateway.conf.test
                 exit 1
               fi
-        
+              sudo rm /etc/nginx/conf.d/gateway.conf.test
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
-        
               sudo nginx -s reload
               echo '✅ Nginx reloaded successfully'
             "

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -60,7 +60,7 @@ jobs:
             --project="$GCP_PROJECT" \
             --tunnel-through-iap
 
-      # 기존 conf 백업(있을 때만) → 임시 파일 검증 → 반영 → reload 실패 시 백업 복구 → 성공 시 백업 제거
+      # 기존 conf를 bak으로 rename → sites-enabled에서 검증 → conf.d에 반영 → reload 실패 시 복구 → 성공 시 bak 제거
       - name: Apply nginx.conf and reload
         run: |
           gcloud compute ssh $NGINX_VM \
@@ -71,27 +71,25 @@ jobs:
               set -e
 
               if [ -f /etc/nginx/conf.d/gateway.conf ]; then
-                sudo cp /etc/nginx/conf.d/gateway.conf /etc/nginx/conf.d/gateway.conf.bak
+                sudo mv /etc/nginx/conf.d/gateway.conf /etc/nginx/conf.d/gateway.conf.bak
               fi
 
-              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.tmp.conf
+              sudo cp /tmp/nginx.conf /etc/nginx/sites-enabled/gateway.tmp.conf
+
               if ! sudo nginx -t; then
                 echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
-                sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
-                if [ -f /etc/nginx/conf.d/gateway.conf.bak ]; then
-                  sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
-                fi
+                sudo rm /etc/nginx/sites-enabled/gateway.tmp.conf
+                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
                 exit 1
               fi
 
-              sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
+              sudo rm /etc/nginx/sites-enabled/gateway.tmp.conf
+              sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf 2>/dev/null || true
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
 
               if ! sudo nginx -s reload; then
-                if [ -f /etc/nginx/conf.d/gateway.conf.bak ]; then
-                  sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
-                  sudo nginx -s reload || true
-                fi
+                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                sudo nginx -s reload || true
                 echo '❌ Nginx reload failed — rolled back to previous gateway.conf'
                 exit 1
               fi

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -69,14 +69,10 @@ jobs:
             --command="
               set -e
           
-              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.test
-              sudo nginx -t
-              if [ \$? -ne 0 ]; then
-                echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
-                sudo rm /etc/nginx/conf.d/gateway.conf.test
-                exit 1
+              if ! sudo nginx -t -c /etc/nginx/nginx.conf -g "include /tmp/nginx.conf;"; then
+              echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
+              exit 1
               fi
-              sudo rm /etc/nginx/conf.d/gateway.conf.test
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
               sudo nginx -s reload
               echo '✅ Nginx reloaded successfully'

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -60,6 +60,7 @@ jobs:
             --project="$GCP_PROJECT" \
             --tunnel-through-iap
 
+        # 기존 gateway.conf를 백업 후 제거 → 검증 → 복구 또는 교체
       - name: Apply nginx.conf and reload
         run: |
           gcloud compute ssh $NGINX_VM \
@@ -69,13 +70,16 @@ jobs:
             --command="
               set -e
           
+              sudo mv /etc/nginx/conf.d/gateway.conf /etc/nginx/conf.d/gateway.conf.bak
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf.tmp.conf
               if ! sudo nginx -t; then
                 echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
                 sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
+                sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
                 exit 1
               fi
               sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
+              sudo mv /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
               sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
               sudo nginx -s reload
               echo '✅ Nginx reloaded successfully'

--- a/.github/workflows/deploy-nginx.yaml
+++ b/.github/workflows/deploy-nginx.yaml
@@ -60,7 +60,7 @@ jobs:
             --project="$GCP_PROJECT" \
             --tunnel-through-iap
 
-        # 기존 conf 백업(있을 때만) → 임시 파일 검증 → 반영 → reload 실패 시 백업 복구 → 성공 시 백업 제거
+      # 기존 conf 백업(있을 때만) → 임시 파일 검증 → 반영 → reload 실패 시 백업 복구 → 성공 시 백업 제거
       - name: Apply nginx.conf and reload
         run: |
           gcloud compute ssh $NGINX_VM \
@@ -78,16 +78,21 @@ jobs:
               if ! sudo nginx -t; then
                 echo '❌ nginx.conf validation failed — gateway.conf is unchanged'
                 sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
-                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                if [ -f /etc/nginx/conf.d/gateway.conf.bak ]; then
+                  sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                fi
                 exit 1
               fi
 
-              sudo mv /etc/nginx/conf.d/gateway.conf.tmp.conf /etc/nginx/conf.d/gateway.conf
+              sudo rm /etc/nginx/conf.d/gateway.conf.tmp.conf
+              sudo cp /tmp/nginx.conf /etc/nginx/conf.d/gateway.conf
 
               if ! sudo nginx -s reload; then
-                echo '❌ nginx reload failed — restoring backup'
-                [ -f /etc/nginx/conf.d/gateway.conf.bak ] && sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
-                sudo nginx -s reload
+                if [ -f /etc/nginx/conf.d/gateway.conf.bak ]; then
+                  sudo cp /etc/nginx/conf.d/gateway.conf.bak /etc/nginx/conf.d/gateway.conf
+                  sudo nginx -s reload || true
+                fi
+                echo '❌ Nginx reload failed — rolled back to previous gateway.conf'
                 exit 1
               fi
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -19,5 +19,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "";
         proxy_pass http://gateway;
+
+        add_header X-Upstream-Addr $upstream_addr always;
     }
 }

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -8,6 +8,9 @@ upstream gateway {
 server {
     listen 80;
 
+    # 게이트웨이 로드밸런싱 테스트용 임시 로그
+    access_log /var/log/nginx/access.log upstream_log;
+
     # 게이트웨이 관련 리버스 프록시 설정 추가
     location / {
         proxy_set_header Host $host;

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -8,9 +8,6 @@ upstream gateway {
 server {
     listen 80;
 
-    # 게이트웨이 로드밸런싱 테스트용 임시 로그
-    access_log /var/log/nginx/access.log upstream_log;
-
     # 게이트웨이 관련 리버스 프록시 설정 추가
     location / {
         proxy_set_header Host $host;
@@ -19,7 +16,5 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "";
         proxy_pass http://gateway;
-
-        add_header X-Upstream-Addr $upstream_addr always;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,5 +19,11 @@ management:
       exposure:
         include: health, info
 
+# /actuator/info 호출 시 게이트웨이 서버명 출력
+info:
+  app:
+    name: gateway
+    hostname: ${HOSTNAME}
+
 server:
   port: 8090

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,7 +33,7 @@ management:
 info:
   app:
     name: gateway
-    hostname: ${HOSTNAME}
+    hostname: ${HOSTNAME:localhost}
 
 server:
   port: 8090

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,13 +13,23 @@ spring:
       discovery:
         service-id: config-server
 
+eureka:
+  instance:
+    prefer-ip-address: true
+    hostname: ${HOSTNAME:localhost}
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+
 management:
   endpoints:
     web:
       exposure:
         include: health, info
 
-# /actuator/info 호출 시 게이트웨이 서버명 출력
+# /actuator/info 호출 시 게이트웨이 서버명 출력(nginx 로드밸런싱 결과 확인용)
 info:
   app:
     name: gateway

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,5 +13,11 @@ spring:
       discovery:
         service-id: config-server
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info
+
 server:
   port: 8090

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,16 @@ spring:
       discovery:
         service-id: config-server
 
+eureka:
+  instance:
+    prefer-ip-address: true
+    hostname: ${HOSTNAME}
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,11 +29,5 @@ management:
       exposure:
         include: health, info
 
-# /actuator/info 호출 시 게이트웨이 서버명 출력(nginx 로드밸런싱 결과 확인용)
-info:
-  app:
-    name: gateway
-    hostname: ${HOSTNAME:localhost}
-
 server:
   port: 8090


### PR DESCRIPTION
### 작업 배경
- 새로 추가한 nginx 배포 워크플로우에 관한 테스트 진행 및 오류 수정

### 작업 내용
- 현재 pr에서 nginx 배포 워크플로우 관련 테스트 진행 및 오류 수정

### 테스트 여부
- nginx 워크플로우 관련 다음의 테스트 통과
  - 현재 pr에서 nginx CI/CD 워크플로우가 정상 동작하는지 확인
  - nginx 배포 성공 시 아래의 명령어를 git bash에서 실행하여 `http://34.50.57.33/actuator/health` api를 호출하는 작업을 20회 수행 후 출력되는 로그의 `X-Upstream-Addr`의 값을 확인
    ```bash
    for i in $(seq 1 20); do
      curl -s -I http://34.50.57.33/
    done
    ``` 
    - nginx의 외부 IP는 34.50.57.33
    - 로그를 통해 확인한 IP 주소가 10.0.0.10, 10.0.0.20, 10.0.0.30 중 하나에 해당하는 게이트웨이의 고정 내부 IP인지 확인 

### 테스트 결과

<details>

<summary>테스트 진행 로그(git bash에서 실행)</summary>

```bash
laptop@DESKTOP-HIBESHV MINGW64 /c/study/sparta/final-project/pgsg/org.pgsg.gateway-server (chore/#16-nginx-deploy-2)
$ for i in $(seq 1 20); do
>   curl -s -I http://34.50.57.33/actuator/health
> done
HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:47 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:47 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:48 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.20:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.30:8090

HTTP/1.1 200 
Server: nginx/1.24.0 (Ubuntu)
Date: Tue, 12 May 2026 15:34:49 GMT
Content-Type: application/vnd.spring-boot.actuator.v3+json
Connection: keep-alive
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
X-Upstream-Addr: 10.0.0.10:8090


laptop@DESKTOP-HIBESHV MINGW64 /c/study/sparta/final-project/pgsg/org.pgsg.gateway-server (chore/#16-nginx-deploy-2)
```

</details>

### 기타

- 테스트를 진행하기 위해 추가했던 nginx 로그 관련 설정은 테스트 종료 후 로그가 불필요하게 누적되는 것을 방지하기 위해 다시 삭제하여 이전으로 원상복구했습니다.
- 테스트 항목 모두 통과 시 현재 pr을 merge할 예정입니다.
- nginx 관련 테스트를 진행하는 과정에서 application.yaml 파일의 설정을 변경하게 되어, 게이트웨이 - 유레카 서버 연동 작업도 일부 진행했습니다.
(현재 게이트웨이를 유레카 서버에 등록하는 것까지는 완료된 상태이며, 게이트웨이 라우팅 기능은 config 서버와 다시 연동되면 별도 확인 예정입니다.)

### 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- #14 #16 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 배포 시 구성 검증·트랜잭션식 롤백 절차를 강화해 잘못된 nginx 설정 적용을 방지하고 안정적인 리로드를 보장합니다.

* **새로운 기능**
  * 서비스 등록/검색을 위한 Eureka 클라이언트 지원을 추가했습니다.

* **보안·관찰성**
  * Actuator 웹 노출 엔드포인트를 health/info로 제한하고 앱 정보 노출을 포함했습니다.
  * 게이트웨이 접근 로그 및 X-Upstream-Addr 헤더를 추가해 요청 추적성을 개선했습니다.

* **문서**
  * 예제 환경파일에 배포 토큰(GPR_TOKEN) 및 Eureka 서버 URL 항목을 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/89-49/gateway-server/pull/17)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->